### PR TITLE
Issue #9

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -9,6 +9,7 @@ from flask import flash
 
 from werkzeug.utils import secure_filename
 
+import sys
 import rq
 from rq.job import Job as RQJob
 
@@ -90,8 +91,17 @@ def upload():
 
         # Check if valid fasta files.
         for f in fnames:
+
+            # Convert to unix filetype (see gh issue #9).
+            with open(f, 'rb') as infile:
+                content = infile.read()
+            with open(f, 'wb') as output:
+                for line in content.splitlines():
+                    output.write(line + b'\n')
+
             if f.split('.')[-1] in tree_extensions:
                 continue
+
             is_fasta = validate_fasta(f)
             if not is_fasta:
                 flash("{} is neither a valid fasta file nor a tree file and will be ignored.".format(os.path.basename(f)))

--- a/app/tasks/rayt_phylo.py
+++ b/app/tasks/rayt_phylo.py
@@ -104,7 +104,7 @@ def run_phyml(run_dir, seed=None):
         return "Input data file is empty.", 0
 
 
-    command = 'phyml --quiet -i {} -m GTR'.format(input_fname)
+    command = 'phyml --leave_duplicates --quiet -i {} -m GTR'.format(input_fname)
 
 
     if seed is not None:


### PR DESCRIPTION
This PR addresses two issues related to phylogenetic tree generation:
- phyml is now run with the flag '--leave_duplicates'. This should also address the issue reported in https://gitlab.gwdg.de/mpievolbio-scicomp/repinpop/-/issues/99.
- all input fasta files are run through a filter that sets a proper '\n' EOL character (addresses #9). DOS EOLsA are problematic in andi (they are ignored).