### PR TITLE
Issue #12

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -86,7 +86,11 @@ def upload():
         dna_extensions = ['fn', 'fna', 'fastn', 'fas', 'fasta']
         aa_extensions = ['fa', 'faa']
         tree_extensions = ['nwk']
-        fnames = [os.path.join(session['tmpdir'], secure_filename(seq.filename)) for seq in seqs]
+
+        # Generate filenames: Intermediate "." by "_" and secure.
+        fnames = [seq.filename for seq in seqs]
+        fnames = ["_".join(fname.split(".")[:-1]) + "." + fname.split(".")[-1] for fname in fnames]
+        fnames = [os.path.join(session['tmpdir'], secure_filename(fname)) for fname in fnames]
         [seq.save(fname) for seq, fname in zip(seqs, fnames)]
 
         # Check if valid fasta files.

--- a/app/utilities/checkers.py
+++ b/app/utilities/checkers.py
@@ -2,6 +2,7 @@ import sys
 import os
 import logging
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def count_lines(fname):
@@ -78,6 +79,7 @@ def parse_results(outdir,
         try:
             results['counts']['repins'][i] = count_lines(cluster_file)
         except:
+            logger.debug("Could not count lines in cluster file %s.", cluster_file)
             repin_checks[i] = 1
 
         results['status']['repins'] = int(all([r == 1 for r in repin_checks]))


### PR DESCRIPTION
This PR changes how input sequence filenames are handled:
Before this change, filenames where copied. This caused problems outlined in #12. Now, all dots but the last are replaced with underscores. 
- [x] Tested locally
- [x] Tested on production server